### PR TITLE
Fixed _wpr_get_backupbuddy_plugin_data()

### DIFF
--- a/wprp.plugins.php
+++ b/wprp.plugins.php
@@ -239,7 +239,7 @@ function _wpr_get_backupbuddy_plugin_data() {
 	if ( $update_data->key_status != 'ok' || version_compare( $update_data->new_version, $current_version, '<=' ) )
 		return false;
 
-	$update_data->plugin_location = $update_data->slug; // needed in _wpr_add_non_extend_plugin_support()
+	$update_data->plugin_location = plugin_basename( pb_backupbuddy::plugin_path() . '/backupbuddy.php' ); // needed in _wpr_add_non_extend_plugin_support()
 
 	return $update_data;
 


### PR DESCRIPTION
Initial function wasn't working, if called outside `is_admin()`. Tested it successfully.
