### PR TITLE
Link to signup flow from "Enter API Key" prompt

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -28,6 +28,9 @@ Author URI: http://hmn.md/
 define( 'WPRP_PLUGIN_SLUG', 'wpremote' );
 define( 'WPRP_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 
+if ( ! defined( 'WPR_URL' ) )
+	define( 'WPR_URL', 'https://wpremote.com/' );
+
 if ( ! defined( 'WPR_API_URL' ) )
 	define( 'WPR_API_URL', 'https://wpremote.com/api/json/' );
 
@@ -128,6 +131,22 @@ if ( empty( $_GET['action'] ) || $_GET['action'] != 'do-core-upgrade' ) :
 	}
 
 endif;
+
+/**
+ * Get a needed URL on the WP Remote site
+ *
+ * @param string      $uri     URI for the URL (optional)
+ * @return string     $url     Fully-qualified URL to WP Remote
+ */
+function wprp_get_wpr_url( $uri = '' ) {
+
+	if ( empty( $uri ) )
+		return WPR_URL;
+
+	$url = rtrim( WPR_URL, '/' );
+	$uri = trim( $uri, '/' );
+	return $url . '/' . $uri . '/';
+}
 
 /**
  * Catch the API calls and load the API

--- a/wprp.admin.php
+++ b/wprp.admin.php
@@ -36,7 +36,7 @@ function wprp_add_api_key_admin_notice() { ?>
 
 			<p>
 
-				<strong>Don't have a WP Remote account yet?</strong> <a href="http://wpremote.dev/register/" target="_blank">Sign up</a>, register your site, and report back once you've grabbed your API key.
+				<strong>Don't have a WP Remote account yet?</strong> <a href="<?php echo esc_url( wprp_get_wpr_url( '/register/' ) ); ?>" target="_blank">Sign up</a>, register your site, and report back once you've grabbed your API key.
 
 			</p>
 
@@ -68,7 +68,7 @@ function wprp_api_key_added_admin_notice() {
 		return; ?>
 
 	<div id="wprp-message" class="updated">
-		<p><strong>WP Remote API Key successfully added</strong>, close this window to go back to <a href="https://wpremote.com/app/">WP Remote</a>.</p>
+		<p><strong>WP Remote API Key successfully added</strong>, close this window to go back to <a href="<?php echo esc_url( wprp_get_wpr_url( '/app/' ) ); ?>">WP Remote</a>.</p>
 	</div>
 
 <?php }


### PR DESCRIPTION
If I'm a new user who has discovered WP Remote from the WordPress.org directory, it can be confusing as to where I'm supposed to get the API I need to enter:

https://www.evernote.com/shard/s2/sh/67115054-0361-4530-a7d0-dcfb34459577/eabeeb6f91b62ee5b552bc53a7ad90f5

We should improve the text to explain where to go if you don't have an API key, and link to a signup flow for users who don't have an account. 

Bonus points to pass their domain and site name to the signup flow, such that it creates the site profile after registration.
