### PR TITLE
spelling mistake on Updating plugin failed error message

### DIFF
--- a/wprp.plugins.php
+++ b/wprp.plugins.php
@@ -134,10 +134,10 @@ function _wprp_update_plugin( $plugin ) {
 		$json = $json->activate_plugin;
 
 		if ( empty( $json->status ) )
-			return array( 'status' => 'error', 'error' => 'The plugin was updated, but failed to re-activate. The activation reuest returned no response' );
+			return array( 'status' => 'error', 'error' => 'The plugin was updated, but failed to re-activate. The activation request returned no response' );
 
 		if ( $json->status != 'success' )
-			return array( 'status' => 'error', 'error' => 'The plugin was updated, but failed to re-activate. The activation reuest returned response: ' . $json->status );
+			return array( 'status' => 'error', 'error' => 'The plugin was updated, but failed to re-activate. The activation request returned response: ' . $json->status );
 	}
 
 	return array( 'status' => 'success' );


### PR DESCRIPTION
In this pull request I've corrected some spelling for the below error message.

`"Updating plugin failed. The plugin was updated, but failed to re-activate. The activation reuest returned no response"`

reuest should be reQuest

see https://www.intercom.io/apps/w5ah62fs/messages/430066/message_threads/535000
