### PR TITLE
Introduce *_plugin_multi API methods

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -47,6 +47,7 @@ if ( version_compare( phpversion(), '5.2.4', '<' ) ) {
 
 require_once( WPRP_PLUGIN_PATH . '/wprp.admin.php' );
 require_once( WPRP_PLUGIN_PATH . '/wprp.compatability.php' );
+require_once( WPRP_PLUGIN_PATH . '/wprp.utils.php' );
 
 // Backups require 3.1
 if ( version_compare( get_bloginfo( 'version' ), '3.1', '>=' ) ) {

--- a/wprp.api.php
+++ b/wprp.api.php
@@ -136,9 +136,20 @@ foreach( WPR_API_Request::get_actions() as $action ) {
 		break;
 
 		case 'update_plugin' :
+		case 'update_plugin_multi':
 		case 'upgrade_plugin' : // 'upgrade' is deprecated language
 
-			$actions[$action] = _wprp_update_plugin( (string) sanitize_text_field( WPR_API_Request::get_arg( 'plugin' ) ) );
+			if ( in_array( $action, array( 'update_plugin', 'upgrade_plugin' ) ) )
+				$plugins = array( WPR_API_Request::get_arg( 'plugin' ) );
+			else
+				$plugins = WPR_API_Request::get_arg( 'plugin' );
+
+			$results = array();
+			foreach( $plugins as $plugin ) {
+				$results[] = _wprp_update_plugin( (string) sanitize_text_field( $plugin ) );
+			}
+
+			$actions[$action] = wprp_get_singular_result( $results );
 
 		break;
 

--- a/wprp.utils.php
+++ b/wprp.utils.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Convert multiple method calls to one result
+ * 
+ * @param array      $results     An array of one or more results.
+ * @return array     $result      One final result.
+ */
+function wprp_get_singular_result( $results ) {
+
+	$final_result = array( 'status' => 'success' );
+	if ( count( $results ) > 1 ) {
+		$all_errors = array();
+		foreach( $results as $result ) {
+			if ( 'error' == $result['status'] ) {
+				$final_result['status'] = 'error';
+				$all_errors[] = $result['error'];
+			}				
+		}
+		if ( ! empty( $all_errors ) )
+			$result['error'] = json_encode( $all_errors );
+	} else if ( count( $results ) == 1 ) {
+		return $results;
+	}
+	return $final_result;
+}


### PR DESCRIPTION
For all of our plugin actions (e.g. installing, deleting, activating, etc.), we should have `*_plugin_multi` API methods so you can perform multiple actions in one call.
