### PR TITLE
Fix notice if strict mode enabled

### DIFF
--- a/wprp.plugins.php
+++ b/wprp.plugins.php
@@ -296,8 +296,8 @@ function _wpr_get_gravity_form_plugin_data() {
         return false;
 
     $version_data  = GFCommon::get_version_info();
-    $gravityFormsUpdate = RGForms::premium_update_push( array() );
-    $plugin_data   = reset( $gravityFormsUpdate );
+    $gravity_forms_update = RGForms::premium_update_push( array() );
+    $plugin_data   = reset( $gravity_forms_update );
 
     if ( empty( $version_data['url'] ) || empty( $version_data['is_valid_key'] ) || empty( $plugin_data['new_version'] ) || empty( $plugin_data['PluginURI'] ) || empty( $plugin_data['slug'] ) )
         return false;


### PR DESCRIPTION
If gravity forms is enabled, and WP_DEBUG is true whilst running WordPress 3.6, you get notices and WP Remote is unable to connect due to notices in the response:

```
<b>Strict Standards</b>:  Only variables should be passed by reference in <b>/srv/www/loggly.dev/wp-content/plugins/wpremote/wprp.plugins.php</b> on line <b>206</b><br />
```
