### PR TITLE
Backups path is not as random as it should be

### DIFF
--- a/wprp.backups.php
+++ b/wprp.backups.php
@@ -375,9 +375,11 @@ class WPRP_Backups extends WPRP_HM_Backup {
 
 		foreach ( array( 'AUTH_KEY', 'SECURE_AUTH_KEY', 'LOGGED_IN_KEY', 'NONCE_KEY', 'AUTH_SALT', 'SECURE_AUTH_SALT', 'LOGGED_IN_SALT', 'NONCE_SALT', 'SECRET_KEY' ) as $constant )
 			if ( defined( $constant ) )
-				$key[] = $constant;
+				$key[] = constant( $constant );
 
- 		return md5( shuffle( $key ) );
+		shuffle( $key );
+
+ 		return md5( serialize( $key ) );
 
 	}
 


### PR DESCRIPTION
The code which generates the backups path has a couple of logic issues which means that it actually creates the same MD5 every time.

We need to cherry-pick the fixes that were made to BackUpWordPress: https://github.com/humanmade/backupwordpress/issues/289
