### PR TITLE
Incompatibility with WordPress 2.9.2

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === The WP Remote WordPress Plugin ===
 Contributors: humanmade, willmot, joehoyle, danielbachhuber, mattheu, pauldewouters, cuvelier, tcrsavage
 Tags: wpremote, remote administration, multiple wordpress
-Requires at least: 2.9
-Tested up to: 3.5
+Requires at least: 3.0
+Tested up to: 3.6
 Stable tag: 2.6
 
 WP Remote is a free web app that enables you to easily manage all of your WordPress powered sites from one place.


### PR DESCRIPTION
We say WP Remote is compatible with WordPress 2.9.2, but it's not because of this in our API:

```
case 'get_site_info' :

            $actions[$action] = array(
                'site_url'  => get_site_url(),
                'home_url'  => get_home_url(),
                'admin_url' => get_admin_url(),
                'backups'   => function_exists( '_wprp_get_backups_info' ) ? _wprp_get_backups_info() : array()
            );
```

Each of those functions was introduced in 3.0.

Should we continue to support 2.9.2? If so, we'll need to come up with alternatives, and update Travis to run against 2.9.2
