### PR TITLE
Plugin update fails to reactivate plugin

### DIFF
--- a/wprp.plugins.php
+++ b/wprp.plugins.php
@@ -116,7 +116,10 @@ function _wprp_update_plugin( $plugin ) {
 
 		// we do a remote request to activate, as we don't want to kill any installs
 		$data = array( 'actions' => array( 'activate_plugin' ), 'plugin' => $plugin, 'timestamp' => (string) time() );
-		$data['wpr_verify_key'] = WPR_API_Request::generate_hash( $data );
+
+		list( $hash ) = WPR_API_Request::generate_hashes( $data );
+
+		$data['wpr_verify_key'] = $hash;
 
 		$args = array( 'body' => $data );
 


### PR DESCRIPTION
In this PR we aim to fix the WPR Plugin which was not reactivating the updated plugin.

The reason for this is because in the last plugin update, we introduced a function undefined warning. 

This fix was tested on two different local sites using a local copy of WP Remote and confirmed to reactivate the plugins.
