### PR TITLE
Return a more useful error than "file_permissions_error"

### DIFF
--- a/wprp.plugins.php
+++ b/wprp.plugins.php
@@ -97,14 +97,17 @@ function _wprp_update_plugin( $plugin ) {
 	$data = ob_get_contents();
 	ob_clean();
 
-	if ( ( ! $result && ! is_null( $result ) ) || $data )
-		return array( 'status' => 'error', 'error' => 'file_permissions_error' );
+	if ( ! empty( $skin->error ) )
 
-	elseif ( is_wp_error( $result ) )
+		return array( 'status' => 'error', 'error' => $upgrader->strings[$skin->error] );
+
+	else if ( is_wp_error( $result ) )
+
 		return array( 'status' => 'error', 'error' => $result->get_error_code() );
 
-	if ( $skin->error )
-		return array( 'status' => 'error', 'error' => $skin->error );
+	else if ( ( ! $result && ! is_null( $result ) ) || $data )
+
+		return array( 'status' => 'error', 'error' => 'Unknown error updating plugin.' );
 
 	// If the plugin was activited, we have to re-activate it
 	if ( $is_active ) {


### PR DESCRIPTION
In https://github.com/humanmade/WP-Remote-WordPress-Plugin/blob/master/wprp.themes.php#L180, we return `file_permissions_error` if the upgrade fails for any reason. This is not a useful error. The Upgrader object will have an error string we can return instead.
