### PR TITLE
Consider removing wprp_ajax_calculate_backup_size()

### DIFF
--- a/wprp.backups.php
+++ b/wprp.backups.php
@@ -491,16 +491,3 @@ function _wprp_get_backups_info() {
 	);
 
 }
-
-/**
- * Calculate the filesize of the site
- *
- * The calculated size is stored in a transient
- */
-function wprp_ajax_calculate_backup_size() {
-
-	WPRP_Backups::get_instance()->get_filesize();
-
-	exit;
-}
-add_action( 'wp_ajax_nopriv_wprp_calculate_backup_size', 'wprp_ajax_calculate_backup_size' );


### PR DESCRIPTION
We don't have any JS in the application, so I'm not quite sure why this exists. It was added in 4babfcee066274a4b0d24efe2bcfa0ad014bb742

@willmot Can you weigh in?
