### PR TITLE
Fix PHP notice for `activate_theme`. There are no arguments passed here.

### DIFF
--- a/wprp.api.php
+++ b/wprp.api.php
@@ -192,7 +192,7 @@ foreach( WPR_API_Request::get_actions() as $action ) {
 
 		case 'activate_theme':
 
-			$actions[$action] = _wprp_activate_theme( (string) sanitize_text_field( WPR_API_Request::get_arg( 'theme' ) ), $api_args );
+			$actions[$action] = _wprp_activate_theme( (string) sanitize_text_field( WPR_API_Request::get_arg( 'theme' ) ) );
 
 		break;
 


### PR DESCRIPTION
```
PHP Notice:  Undefined variable: api_args in /srv/www/wpremote-test.dev/wp-content/plugins/wpremote/wprp.api.php on line 195
```
