### PR TITLE
Support API key reset request(s) from the mothership

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -99,6 +99,30 @@ function wprp_catch_api_call() {
 add_action( 'init', 'wprp_catch_api_call', 1 );
 
 /**
+ * Check for a bat signal from the mothership
+ * 
+ * @since 2.7.0
+ */
+function wprp_check_bat_signal() {
+
+	$bat_signal_key = 'wprp_bat_signal';
+
+	if ( false === get_transient( $bat_signal_key ) ) {
+
+		$bat_signal_url = trailingslashit( WPR_URL ) . 'bat-signal/';
+		$response = wp_remote_get( $bat_signal_url );
+		$response_body = wp_remote_retrieve_body( $response );
+		if ( 'destroy the evidence!' == trim( $response_body ) )
+			delete_option( 'wpr_api_key' );
+
+		// One request per day
+		set_transient( $bat_signal_key, 'the coast is clear', 60 * 60 * 24 );
+	}
+
+}
+add_action( 'init', 'wprp_check_bat_signal' );
+
+/**
  * Get the stored WPR API key
  *
  * @return mixed


### PR DESCRIPTION
To better protect users in a situation where the mothership has been compromised, let's support API key reset requests from the mothership.

Specifically, this comes in two parts:
- [x] WP Remote the app should be able to delete the API key stored in a given site (thus forcing a new API key to be entered). In situations where the user is applying an API key by a filter, the API request to delete an API key should also set an option that the filter checks (e.g. break the filter so the user has to perform some action).
- [x] WP Remote the plugin should periodically check WP Remote the app for a bat signal. If the bat signal is shown, then delete the API key and await further instructions.
