### PR TITLE
Support for FTP constants in wp-config

### DIFF
--- a/wprp.api.php
+++ b/wprp.api.php
@@ -129,6 +129,23 @@ foreach( WPR_API_Request::get_actions() as $action ) {
 
 		break;
 
+		case 'get_constants':
+
+			$constants = array();
+			if ( is_array( WPR_API_Request::get_arg( 'constants' ) ) ) {
+
+				foreach( WPR_API_Request::get_arg( 'constants' ) as $constant ) {
+					if ( defined( $constant ) )
+						$constants[$constant] = constant( $constant );
+					else
+						$constants[$constant] = null;
+				}
+
+			}
+			$actions[$action] = $constants;
+
+		break;
+
 		case 'upgrade_core' :
 
 			$actions[$action] = _wprp_upgrade_core();


### PR DESCRIPTION
Core supports a user defining FTP username / password / host constants in the wp-config.php file. However, WP Remote still prompts the user even if these constants are defined.

If these constants are defined, we should default to them and make sure the application knows about them.
