### PR TITLE
If DB bump takes time, heartbeat breaks

### DIFF
--- a/wprp.backups.php
+++ b/wprp.backups.php
@@ -484,10 +484,10 @@ class WPRP_Backups extends WPRP_HM_Backup {
 		$times = array();
 
 		if ( file_exists( $heartbeat ) )
-			return (int) file_get_contents( $heartbeat );
+			$times[] = (int) file_get_contents( $heartbeat );
 
 		if ( file_exists( $database ) )
-			return (int) filemtime( $database );
+			$times[] = (int) filemtime( $database );
 
 		if ( $times )
 			return max( $times );


### PR DESCRIPTION
With the new file manifest / heartbeat backup system introduced in #81 the process will fail if the `mysqldump` for `mysqldumb_fallback` takes longer than 300 seconds. This is because the heartbeat is not updated, so the next backup check thinks the backup process has died, whereas it's actually still doing the db export.

One solution to this problem is to use the `filemtime` of the backup file as a _possible_ heartbeat, so the `heartbeat_timestamp` is a collection of modified times, where the latest time is chosen. For example, I used the below code to fix this issue when dumbing a DB with 25k+ tables:

``` PHP
private function get_heartbeat_timestamp() {

    $heartbeat = $this->get_path() . '/.heartbeat-timestamp';
    $database = $this->get_database_dump_filepath();

    $times = array();

    if ( file_exists( $heartbeat ) )
        return (int) file_get_contents( $heartbeat );

    if ( file_exists( $database ) )
        return (int) filemtime( $database );

    if ( $times )
        return max( $times );

    return false;
}
```

This also raises the question, why do we have a heartbeat file as opposed to just checking `filemtime` of the ZIP or DB backup file?
