### PR TITLE
Misc fixes to the file manifest backup approach

### DIFF
--- a/wprp.backups.php
+++ b/wprp.backups.php
@@ -557,8 +557,8 @@ class WPRP_Backups extends WPRP_HM_Backup {
 		if ( false == ( $process_id = $this->get_backup_process_id() ) )
 			return false;
 
-		// If it hasn't been modified in the last 300 seconds, we're likely dead
-		if ( ( time() - $this->get_heartbeat_timestamp() ) > 300 )
+		// If it hasn't been modified in the last 90 seconds, we're likely dead
+		if ( ( time() - $this->get_heartbeat_timestamp() ) > 90 )
 			return false;
 
 		return true;


### PR DESCRIPTION
For instance:

`'__return_false'` is a string that ends up evaluating as true so we're using
file manifest all the time.

We actually just want to opt-in to using the file manifest approach.
