### PR TITLE
File size calculating is borked entirely

### DIFF
--- a/wprp.api.php
+++ b/wprp.api.php
@@ -79,6 +79,10 @@ if ( class_exists( 'WPRP_Log' ) )
 if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG )
 	error_reporting( 0 );
 
+// Temp hack so our requests to verify file size are signed.
+global $wprp_noauth_nonce;
+$wprp_noauth_nonce = wp_create_nonce( 'wprp_calculate_backup_size' );
+
 // Log in as admin
 // TODO what about if admin use doesn't exists?
 wp_set_current_user( 1 );

--- a/wprp.backups.php
+++ b/wprp.backups.php
@@ -181,7 +181,8 @@ class WPRP_Backups extends WPRP_HM_Backup {
 
 		// we dont know the size yet, fire off a remote request to get it for later
 		// it can take some time so we have a small timeout then return "Calculating"
-		wp_remote_get( add_query_arg( array( 'action' => 'wprp_calculate_backup_size', 'backup_excludes' => $this->get_excludes() ), admin_url( 'admin-ajax.php' ) ), array( 'timeout' => 0.1, 'sslverify' => false ) );
+		global $wprp_noauth_nonce;
+		wp_remote_get( add_query_arg( array( 'action' => 'wprp_calculate_backup_size', 'backup_excludes' => $this->get_excludes() ), add_query_arg( '_wpnonce', $wprp_noauth_nonce, admin_url( 'admin-ajax.php' ) ) ), array( 'timeout' => 0.1, 'sslverify' => false ) );
 
 		return __( 'Calculating', 'wpremote' );
 
@@ -670,6 +671,9 @@ function _wprp_get_backups_info() {
  * The calculated size is stored in a transient
  */
 function wprp_ajax_calculate_backup_size() {
+
+	if ( ! wp_verify_nonce( $_GET['_wpnonce'], 'wprp_calculate_backup_size' ) )
+		exit;
 
 	WPRP_Backups::get_instance()->get_filesize();
 


### PR DESCRIPTION
It [uses the admin-ajax callback](https://github.com/humanmade/WP-Remote-WordPress-Plugin/blob/0001900e6ed3ecff5abe6ffaf29a52cf1981e3b3/wprp.backups.php#L203) I removed in #87 

Considering it was a public admin ajax endpoint though, I don't think we should restore it. We'll need to find another solution.

cc @willmot 
