### PR TITLE
Apply the file manifest filter in the proper place

### DIFF
--- a/wprp.backups.php
+++ b/wprp.backups.php
@@ -25,8 +25,6 @@ class WPRP_Backups extends WPRP_HM_Backup {
 
 		if ( empty( self::$instance ) ) {
 			self::$instance = new WPRP_Backups();
-			self::$instance->set_is_using_file_manifest( apply_filters( 'wprp_backups_use_file_manifest', false ) );
-
 		}
 
 		return self::$instance;

--- a/wprp.hm.backup.php
+++ b/wprp.hm.backup.php
@@ -492,7 +492,7 @@ class WPRP_HM_Backup {
 	 * @access public
 	 */
 	public function is_using_file_manifest() {
-		return (bool)$this->using_file_manifest;
+		return apply_filters( 'hmbkp_use_file_manifest', (bool)$this->using_file_manifest );
 	}
 
 	/**


### PR DESCRIPTION
We should always apply in `set_using_file_manifest()` so the filter overrides whatever argument we're passing in the API request.
