### PR TITLE
Key off the `WPE_APIKEY` constant, as `IS_WPE` is an environment variable

### DIFF
--- a/wprp.integration.php
+++ b/wprp.integration.php
@@ -9,7 +9,7 @@
 function _wprp_integration_get_web_host() {
 
 	// WP Engine
-	if ( defined( 'IS_WPE' ) && IS_WPE )
+	if ( defined( 'WPE_APIKEY' ) && WPE_APIKEY )
 		return 'wpengine';
 
 	return 'unknown';


### PR DESCRIPTION
Fixes our detection mechanism for seeing whether the site is on WP Engine
