### PR TITLE
Be more intelligent about the time we're waiting to report a backup process as dead

### DIFF
--- a/wprp.backups.php
+++ b/wprp.backups.php
@@ -531,7 +531,10 @@ class WPRP_Backups extends WPRP_HM_Backup {
 			return false;
 
 		// When safe mode is enabled, WPRP can't modify max_execution_time
-		$time_to_wait = ( self::is_safe_mode_active() ) ? ini_get( 'max_execution_time' ) : 90;
+		if ( self::is_safe_mode_active() && ini_get( 'max_execution_time' ) )
+			$time_to_wait = ini_get( 'max_execution_time' );
+		else
+			$time_to_wait = 90;
 
 		// If the heartbeat has been modified in the last 90 seconds, we might not be dead
 		if ( ( time() - $this->get_heartbeat_timestamp() ) < $time_to_wait )


### PR DESCRIPTION
On hosts where the `max_execution_time` can't be modified on the fly, set the
time to wait based on the max_execution_time value.

This means we'll be waiting a shorter period of time before restarting the
backup process.
