### PR TITLE
Ensure the admin notice to enter the API key is always displayed

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,7 @@ You can email us at support@wpremote.com for support.
 #### 2.7.2 (?? ???? ???)
 
 * Misc improvements to the accuracy of the backup restart mechanism.
+* Inline styles to insure the API key prompt always appears, even if a theme or plugin may hide admin notices.
 
 #### 2.7.1 (23 December 2013)
 

--- a/wprp.admin.php
+++ b/wprp.admin.php
@@ -20,7 +20,7 @@ add_action( 'admin_menu', 'wprp_setup_admin' );
  */
 function wprp_add_api_key_admin_notice() { ?>
 
-	<div id="wprp-message" class="updated">
+	<div id="wprp-message" class="updated" style="display:block !important;">
 
 		<form method="post" action="options.php">
 


### PR DESCRIPTION
An all to frequent problem users run into is the inability to enter their API key via the admin notice we use as settings UI. The common cause of this is another plugin, or the theme, hiding admin notices in the admin.

We can fight back by including `display: none !important` as an inline style :)
