### PR TITLE
update our security plugin checks & links

### DIFF
--- a/wprp.compatability.php
+++ b/wprp.compatability.php
@@ -50,7 +50,7 @@ function wprp_security_admin_notice() {
 
 				<?php _e( 'The plugin', 'wpremote' );?> <strong><?php echo esc_attr( $plugin_name ); ?></strong> <?php _e( 'may cause issues with WP Remote.', 'wpremote' ); ?>
 
-				<a href="https://wpremote.com/support-center/troubleshooting/incorrect-version-numbers-false-positives/ "> <?php _e( 'Click here for instructions on how to resolve this issue', 'wpremote' ); ?> </a>
+				<a href="https://wpremote.com/support-center/troubleshooting/incorrect-version-numbers-false-positives/" target="_blank"> <?php _e( 'Click here for instructions on how to resolve this issue', 'wpremote' ); ?> </a>
 
 			</p>
 


### PR DESCRIPTION
In the WPRP we check if users have a security plugin installed. Some of the plugins we check no longer cause issues, or doesn't link to the correct documentation.
