### PR TITLE
Plugin incorrectly reports new version available on child themes

### DIFF
--- a/wprp.themes.php
+++ b/wprp.themes.php
@@ -44,7 +44,8 @@ function _wprp_get_themes() {
 		// WordPress 3.4+
 		if ( is_object( $theme ) && is_a( $theme, 'WP_Theme' ) ) {
 
-			$new_version = isset( $current->response[$theme['Template']] ) ? $current->response[$theme['Template']]['new_version'] : null;
+			/* @var $theme WP_Theme */
+			$new_version = isset( $current->response[$theme->get_stylesheet()] ) ? $current->response[$theme->get_stylesheet()]['new_version'] : null;
 
 			$theme_array = array(
 				'Name'           => $theme->get( 'Name' ),
@@ -63,7 +64,7 @@ function _wprp_get_themes() {
 
 		} else {
 
-			$new_version = isset( $current->response[$theme['Template']] ) ? $current->response[$theme['Template']]['new_version'] : null;
+			$new_version = isset( $current->response[$theme['Stylesheet']] ) ? $current->response[$theme['Stylesheet']]['new_version'] : null;
 
 			if ( $active == $theme['Name'] )
 				$themes[$key]['active'] = true;


### PR DESCRIPTION
Bug occurs when the parent theme has an update, all child themes will report the same update available

https://static.intercomcdn.com/attachments/302929-78462d465e5deabb4dd273cffa5a829772ad6c8e-WP_Remote_-_2014-07-16_16.57.19.png?1405555965
